### PR TITLE
Use currency symbol XRP over ROOT everywhere

### DIFF
--- a/packages/page-accounts/src/Accounts/Summary.tsx
+++ b/packages/page-accounts/src/Accounts/Summary.tsx
@@ -23,6 +23,7 @@ function Summary ({ balance, className }: Props) {
         <FormatBalance
           className={balance ? '' : '--tmp'}
           value={balance?.total || 1}
+          format={[6, "ROOT" ]}
         />
       </CardSummary>
       <CardSummary
@@ -32,12 +33,14 @@ function Summary ({ balance, className }: Props) {
         <FormatBalance
           className={balance ? '' : '--tmp'}
           value={balance?.transferrable || 1}
+          format={[6, "ROOT" ]}
         />
       </CardSummary>
       <CardSummary label={t<string>('total locked')}>
         <FormatBalance
           className={balance ? '' : '--tmp'}
           value={balance?.locked || 1}
+          format={[6, "ROOT" ]}
         />
       </CardSummary>
       {balance?.bonded.gtn(0) &&
@@ -45,21 +48,21 @@ function Summary ({ balance, className }: Props) {
           className='media--1100'
           label={t<string>('bonded')}
         >
-          <FormatBalance value={balance.bonded} />
+          <FormatBalance value={balance.bonded}  format={[6, "ROOT" ]}/>
         </CardSummary>}
       {balance?.redeemable.gtn(0) &&
         <CardSummary
           className='media--1500'
           label={t<string>('redeemable')}
         >
-          <FormatBalance value={balance.redeemable} />
+          <FormatBalance value={balance.redeemable} format={[6, "ROOT" ]} />
         </CardSummary>}
       {balance?.unbonding.gtn(0) &&
         <CardSummary
           className='media--1300'
           label={t<string>('unbonding')}
         >
-          <FormatBalance value={balance.unbonding} />
+          <FormatBalance value={balance.unbonding} format={[6, "ROOT" ]}/>
         </CardSummary>}
     </SummaryBox>
   );

--- a/packages/page-accounts/src/Accounts/Summary.tsx
+++ b/packages/page-accounts/src/Accounts/Summary.tsx
@@ -22,8 +22,8 @@ function Summary ({ balance, className }: Props) {
       <CardSummary label={t<string>('total balance')}>
         <FormatBalance
           className={balance ? '' : '--tmp'}
+          format={[6, 'ROOT']}
           value={balance?.total || 1}
-          format={[6, "ROOT" ]}
         />
       </CardSummary>
       <CardSummary
@@ -32,15 +32,15 @@ function Summary ({ balance, className }: Props) {
       >
         <FormatBalance
           className={balance ? '' : '--tmp'}
+          format={[6, 'ROOT']}
           value={balance?.transferrable || 1}
-          format={[6, "ROOT" ]}
         />
       </CardSummary>
       <CardSummary label={t<string>('total locked')}>
         <FormatBalance
           className={balance ? '' : '--tmp'}
+          format={[6, 'ROOT']}
           value={balance?.locked || 1}
-          format={[6, "ROOT" ]}
         />
       </CardSummary>
       {balance?.bonded.gtn(0) &&
@@ -48,21 +48,30 @@ function Summary ({ balance, className }: Props) {
           className='media--1100'
           label={t<string>('bonded')}
         >
-          <FormatBalance value={balance.bonded}  format={[6, "ROOT" ]}/>
+          <FormatBalance
+            format={[6, 'ROOT']}
+            value={balance.bonded}
+          />
         </CardSummary>}
       {balance?.redeemable.gtn(0) &&
         <CardSummary
           className='media--1500'
           label={t<string>('redeemable')}
         >
-          <FormatBalance value={balance.redeemable} format={[6, "ROOT" ]} />
+          <FormatBalance
+            format={[6, 'ROOT']}
+            value={balance.redeemable}
+          />
         </CardSummary>}
       {balance?.unbonding.gtn(0) &&
         <CardSummary
           className='media--1300'
           label={t<string>('unbonding')}
         >
-          <FormatBalance value={balance.unbonding} format={[6, "ROOT" ]}/>
+          <FormatBalance
+            format={[6, 'ROOT']}
+            value={balance.unbonding}
+          />
         </CardSummary>}
     </SummaryBox>
   );

--- a/packages/page-settings/src/useChainInfo.ts
+++ b/packages/page-settings/src/useChainInfo.ts
@@ -31,7 +31,7 @@ function useChainInfoImpl (): ChainInfo | null {
           ? api.registry.chainSS58
           : DEFAULT_SS58.toNumber(),
         tokenDecimals: (api.registry.chainDecimals || [DEFAULT_DECIMALS.toNumber()])[0],
-        tokenSymbol: (api.registry.chainTokens || formatBalance.getDefaults().unit)[0],
+        tokenSymbol: ('XRP' || formatBalance.getDefaults().unit)[0],
         types: getSpecTypes(api.registry, systemChain, api.runtimeVersion.specName, api.runtimeVersion.specVersion) as unknown as Record<string, string>
       }
       : null,

--- a/packages/page-settings/src/useExtensions.ts
+++ b/packages/page-settings/src/useExtensions.ts
@@ -53,7 +53,7 @@ function saveProperties (api: ApiPromise, { name, version }: InjectedExtension):
     extensionVersion: version,
     ss58Format: api.registry.chainSS58,
     tokenDecimals: api.registry.chainDecimals[0],
-    tokenSymbol: api.registry.chainTokens[0]
+    tokenSymbol: 'XRP'
   };
 
   store.set(storeKey, allProperties);
@@ -74,7 +74,7 @@ function hasCurrentProperties (api: ApiPromise, { extension }: ExtensionKnown): 
 
   return ss58Format === api.registry.chainSS58 &&
     tokenDecimals === api.registry.chainDecimals[0] &&
-    tokenSymbol === api.registry.chainTokens[0];
+    tokenSymbol === 'XRP';
 }
 
 // filter extensions based on the properties we have available

--- a/packages/page-staking/src/Actions/Account/Unbond.tsx
+++ b/packages/page-staking/src/Actions/Account/Unbond.tsx
@@ -54,9 +54,9 @@ function Unbond ({ controllerId, onClose, stakingLedger, stashId }: Props): Reac
             label={t<string>('unbond amount')}
             labelExtra={
               <FormatBalance
+                format={[6, 'ROOT']}
                 label={<span className='label'>{t<string>('bonded')}</span>}
                 value={maxBalance}
-                format={[6, "ROOT" ]}
               />
             }
             maxValue={maxBalance}

--- a/packages/page-staking/src/Actions/Account/Unbond.tsx
+++ b/packages/page-staking/src/Actions/Account/Unbond.tsx
@@ -56,6 +56,7 @@ function Unbond ({ controllerId, onClose, stakingLedger, stashId }: Props): Reac
               <FormatBalance
                 label={<span className='label'>{t<string>('bonded')}</span>}
                 value={maxBalance}
+                format={[6, "ROOT" ]}
               />
             }
             maxValue={maxBalance}

--- a/packages/page-staking/src/Actions/Pool/Unbond.tsx
+++ b/packages/page-staking/src/Actions/Pool/Unbond.tsx
@@ -49,9 +49,9 @@ function Unbond ({ className, controllerId, maxUnbond, onClose, poolId }: Props)
             label={t<string>('amount to unbond')}
             labelExtra={
               <FormatBalance
+                format={[6, 'ROOT']}
                 label={<span className='label'>{t<string>('bonded')}</span>}
                 value={maxUnbond}
-                format={[6, "ROOT" ]}
               />
             }
             maxValue={maxUnbond}

--- a/packages/page-staking/src/Actions/Pool/Unbond.tsx
+++ b/packages/page-staking/src/Actions/Pool/Unbond.tsx
@@ -51,6 +51,7 @@ function Unbond ({ className, controllerId, maxUnbond, onClose, poolId }: Props)
               <FormatBalance
                 label={<span className='label'>{t<string>('bonded')}</span>}
                 value={maxUnbond}
+                format={[6, "ROOT" ]}
               />
             }
             maxValue={maxUnbond}

--- a/packages/page-staking/src/Actions/index.tsx
+++ b/packages/page-staking/src/Actions/index.tsx
@@ -112,7 +112,7 @@ function getValue (stashTypeIndex: number, { bondedNoms, bondedNone, bondedTotal
 function formatTotal (stashTypeIndex: number, state: State): React.ReactNode {
   const value = getValue(stashTypeIndex, state);
 
-  return value && <FormatBalance value={value} />;
+  return value && <FormatBalance value={value} format={[6, "ROOT" ]}/>;
 }
 
 function Actions ({ className = '', isInElection, minCommission, ownPools, ownStashes, targets }: Props): React.ReactElement<Props> {

--- a/packages/page-staking/src/Actions/index.tsx
+++ b/packages/page-staking/src/Actions/index.tsx
@@ -112,7 +112,10 @@ function getValue (stashTypeIndex: number, { bondedNoms, bondedNone, bondedTotal
 function formatTotal (stashTypeIndex: number, state: State): React.ReactNode {
   const value = getValue(stashTypeIndex, state);
 
-  return value && <FormatBalance value={value} format={[6, "ROOT" ]}/>;
+  return value && <FormatBalance
+    format={[6, 'ROOT']}
+    value={value}
+  />;
 }
 
 function Actions ({ className = '', isInElection, minCommission, ownPools, ownStashes, targets }: Props): React.ReactElement<Props> {

--- a/packages/page-staking/src/Slashes/Row.tsx
+++ b/packages/page-staking/src/Slashes/Row.tsx
@@ -70,16 +70,16 @@ function Row ({ index, isSelected, onSelect, slash: { era, isMine, slash: { othe
         ))}
       </td>
       <td className='number together'>
-        <FormatBalance value={own} />
+        <FormatBalance value={own} format={[6, "ROOT" ]} />
       </td>
       <td className='number together'>
-        <FormatBalance value={totalOther} />
+        <FormatBalance value={totalOther} format={[6, "ROOT" ]}/>
       </td>
       <td className='number together'>
-        <FormatBalance value={total} />
+        <FormatBalance value={total} format={[6, "ROOT" ]}/>
       </td>
       <td className='number together'>
-        <FormatBalance value={payout} />
+        <FormatBalance value={payout} format={[6, "ROOT" ]}/>
       </td>
       {!api.query.staking.earliestUnappliedSlash && !!api.consts.staking.slashDeferDuration && (
         <td className='number together'>

--- a/packages/page-staking/src/Slashes/Row.tsx
+++ b/packages/page-staking/src/Slashes/Row.tsx
@@ -70,16 +70,28 @@ function Row ({ index, isSelected, onSelect, slash: { era, isMine, slash: { othe
         ))}
       </td>
       <td className='number together'>
-        <FormatBalance value={own} format={[6, "ROOT" ]} />
+        <FormatBalance
+          format={[6, 'ROOT']}
+          value={own}
+        />
       </td>
       <td className='number together'>
-        <FormatBalance value={totalOther} format={[6, "ROOT" ]}/>
+        <FormatBalance
+          format={[6, 'ROOT']}
+          value={totalOther}
+        />
       </td>
       <td className='number together'>
-        <FormatBalance value={total} format={[6, "ROOT" ]}/>
+        <FormatBalance
+          format={[6, 'ROOT']}
+          value={total}
+        />
       </td>
       <td className='number together'>
-        <FormatBalance value={payout} format={[6, "ROOT" ]}/>
+        <FormatBalance
+          format={[6, 'ROOT']}
+          value={payout}
+        />
       </td>
       {!api.query.staking.earliestUnappliedSlash && !!api.consts.staking.slashDeferDuration && (
         <td className='number together'>

--- a/packages/page-staking/src/Slashes/Summary.tsx
+++ b/packages/page-staking/src/Slashes/Summary.tsx
@@ -56,7 +56,7 @@ function Summary ({ slash: { era, nominators, reporters, total, validators } }: 
         />
       )}
       <CardSummary label={t<string>('total')}>
-        <FormatBalance value={total} />
+        <FormatBalance value={total} format={[6, "ROOT" ]} />
       </CardSummary>
     </SummaryBox>
   );

--- a/packages/page-staking/src/Slashes/Summary.tsx
+++ b/packages/page-staking/src/Slashes/Summary.tsx
@@ -56,7 +56,10 @@ function Summary ({ slash: { era, nominators, reporters, total, validators } }: 
         />
       )}
       <CardSummary label={t<string>('total')}>
-        <FormatBalance value={total} format={[6, "ROOT" ]} />
+        <FormatBalance
+          format={[6, 'ROOT']}
+          value={total}
+        />
       </CardSummary>
     </SummaryBox>
   );

--- a/packages/page-staking/src/Targets/Summary.tsx
+++ b/packages/page-staking/src/Targets/Summary.tsx
@@ -75,9 +75,9 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
         >
           <FormatBalance
             className={progressStake.isBlurred ? '--tmp' : ''}
+            format={[6, 'ROOT']}
             value={progressStake.value}
             withSi
-            format={[6, "ROOT" ]}
           />
         </CardSummary>
       </section>
@@ -98,17 +98,17 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
         >
           <span className={progressAvg.isBlurred ? '--tmp' : ''}>
             <FormatBalance
+              format={[6, 'ROOT']}
               value={progressAvg.value}
               withCurrency={false}
               withSi
-              format={[6, "ROOT" ]}
             />
             &nbsp;/&nbsp;
             <FormatBalance
               className={progressAvg.isBlurred ? '--tmp' : ''}
+              format={[6, 'ROOT']}
               value={progressAvg.total}
               withSi
-              format={[6, "ROOT" ]}
             />
           </span>
         </CardSummary>
@@ -123,18 +123,18 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
                 : t<string>('min nominated')}
           >
             <FormatBalance
+              format={[6, 'ROOT']}
               value={minNominated}
               withCurrency={!minNominatorBond}
               withSi
-              format={[6, "ROOT" ]}
             />
             {minNominatorBond && (
               <>
                 &nbsp;/&nbsp;
                 <FormatBalance
+                  format={[6, 'ROOT']}
                   value={minNominatorBond}
                   withSi
-                  format={[6, "ROOT" ]}
                 />
               </>
             )}
@@ -145,9 +145,9 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
         <CardSummary label={t<string>('last reward')}>
           <FormatBalance
             className={lastReward ? '' : '--tmp'}
+            format={[6, 'ROOT']}
             value={lastReward || 1}
             withSi
-            format={[6, "ROOT" ]}
           />
         </CardSummary>
       </section>

--- a/packages/page-staking/src/Targets/Summary.tsx
+++ b/packages/page-staking/src/Targets/Summary.tsx
@@ -77,6 +77,7 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
             className={progressStake.isBlurred ? '--tmp' : ''}
             value={progressStake.value}
             withSi
+            format={[6, "ROOT" ]}
           />
         </CardSummary>
       </section>
@@ -100,12 +101,14 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
               value={progressAvg.value}
               withCurrency={false}
               withSi
+              format={[6, "ROOT" ]}
             />
             &nbsp;/&nbsp;
             <FormatBalance
               className={progressAvg.isBlurred ? '--tmp' : ''}
               value={progressAvg.total}
               withSi
+              format={[6, "ROOT" ]}
             />
           </span>
         </CardSummary>
@@ -123,6 +126,7 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
               value={minNominated}
               withCurrency={!minNominatorBond}
               withSi
+              format={[6, "ROOT" ]}
             />
             {minNominatorBond && (
               <>
@@ -130,6 +134,7 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
                 <FormatBalance
                   value={minNominatorBond}
                   withSi
+                  format={[6, "ROOT" ]}
                 />
               </>
             )}
@@ -142,6 +147,7 @@ function Summary ({ avgStaked, className, lastEra, lowStaked, minNominated, minN
             className={lastReward ? '' : '--tmp'}
             value={lastReward || 1}
             withSi
+            format={[6, "ROOT" ]}
           />
         </CardSummary>
       </section>

--- a/packages/page-staking/src/Targets/Validator.tsx
+++ b/packages/page-staking/src/Targets/Validator.tsx
@@ -129,9 +129,18 @@ function Validator ({ allSlashes, canSelect, filterName, info: { accountId, bond
       <td className='number media--1200 no-pad-right'>{numNominators || ''}</td>
       <td className='number media--1200 no-pad-left'>{nominatedBy.length || ''}</td>
       <td className='number media--1100'>{commissionPer.toFixed(2)}%</td>
-      <td className='number together'>{!bondTotal.isZero() && <FormatBalance value={bondTotal} format={[6, "ROOT" ]}/>}</td>
-      <td className='number together media--900'>{!bondOwn.isZero() && <FormatBalance value={bondOwn} format={[6, "ROOT" ]}/>}</td>
-      <td className='number together media--1600'>{!bondOther.isZero() && <FormatBalance value={bondOther} format={[6, "ROOT" ]} />}</td>
+      <td className='number together'>{!bondTotal.isZero() && <FormatBalance
+        format={[6, 'ROOT']}
+        value={bondTotal}
+      />}</td>
+      <td className='number together media--900'>{!bondOwn.isZero() && <FormatBalance
+        format={[6, 'ROOT']}
+        value={bondOwn}
+      />}</td>
+      <td className='number together media--1600'>{!bondOther.isZero() && <FormatBalance
+        format={[6, 'ROOT']}
+        value={bondOther}
+      />}</td>
       <td className='number together'>{(stakedReturnCmp > 0) && <>{stakedReturnCmp.toFixed(2)}%</>}</td>
       <td>
         {!isBlocking && (canSelect || isSelected) && (

--- a/packages/page-staking/src/Targets/Validator.tsx
+++ b/packages/page-staking/src/Targets/Validator.tsx
@@ -129,9 +129,9 @@ function Validator ({ allSlashes, canSelect, filterName, info: { accountId, bond
       <td className='number media--1200 no-pad-right'>{numNominators || ''}</td>
       <td className='number media--1200 no-pad-left'>{nominatedBy.length || ''}</td>
       <td className='number media--1100'>{commissionPer.toFixed(2)}%</td>
-      <td className='number together'>{!bondTotal.isZero() && <FormatBalance value={bondTotal} />}</td>
-      <td className='number together media--900'>{!bondOwn.isZero() && <FormatBalance value={bondOwn} />}</td>
-      <td className='number together media--1600'>{!bondOther.isZero() && <FormatBalance value={bondOther} />}</td>
+      <td className='number together'>{!bondTotal.isZero() && <FormatBalance value={bondTotal} format={[6, "ROOT" ]}/>}</td>
+      <td className='number together media--900'>{!bondOwn.isZero() && <FormatBalance value={bondOwn} format={[6, "ROOT" ]}/>}</td>
+      <td className='number together media--1600'>{!bondOther.isZero() && <FormatBalance value={bondOther} format={[6, "ROOT" ]} />}</td>
       <td className='number together'>{(stakedReturnCmp > 0) && <>{stakedReturnCmp.toFixed(2)}%</>}</td>
       <td>
         {!isBlocking && (canSelect || isSelected) && (

--- a/packages/page-staking/src/Validators/Address/StakeOther.tsx
+++ b/packages/page-staking/src/Validators/Address/StakeOther.tsx
@@ -75,9 +75,9 @@ function StakeOther ({ nominators, stakeOther }: Props): React.ReactElement<Prop
           renderChildren={rewarded && rewarded[1]}
           summary={
             <FormatBalance
+              format={[6, 'ROOT']}
               labelPost={` (${rewarded ? rewarded[0] : '0'})`}
               value={rewardedTotal}
-              format={[6, "ROOT" ]}
             />
           }
         />

--- a/packages/page-staking/src/Validators/Address/StakeOther.tsx
+++ b/packages/page-staking/src/Validators/Address/StakeOther.tsx
@@ -77,6 +77,7 @@ function StakeOther ({ nominators, stakeOther }: Props): React.ReactElement<Prop
             <FormatBalance
               labelPost={` (${rewarded ? rewarded[0] : '0'})`}
               value={rewardedTotal}
+              format={[6, "ROOT" ]}
             />
           }
         />

--- a/packages/page-staking/src/Validators/Address/index.tsx
+++ b/packages/page-staking/src/Validators/Address/index.tsx
@@ -196,8 +196,8 @@ function Address ({ address, className = '', filterName, hasQueries, isElected, 
                   <>
                     <h5>{t<string>('own stake')}</h5>
                     <FormatBalance
+                      format={[6, 'ROOT']}
                       value={stakeOwn}
-                      format={[6, "ROOT" ]}
                     />
                   </>
                 )}

--- a/packages/page-staking/src/Validators/Address/index.tsx
+++ b/packages/page-staking/src/Validators/Address/index.tsx
@@ -197,6 +197,7 @@ function Address ({ address, className = '', filterName, hasQueries, isElected, 
                     <h5>{t<string>('own stake')}</h5>
                     <FormatBalance
                       value={stakeOwn}
+                      format={[6, "ROOT" ]}
                     />
                   </>
                 )}

--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -123,7 +123,7 @@ async function retrieve (api: ApiPromise, injectedPromise: Promise<InjectedExten
     properties: registry.createType('ChainProperties', {
       ss58Format: api.registry.chainSS58,
       tokenDecimals: api.registry.chainDecimals,
-      tokenSymbol: api.registry.chainTokens
+      tokenSymbol: 'XRP'
     }),
     systemChain: (systemChain || '<unknown>').toString(),
     systemChainType,

--- a/packages/react-components/src/AddressInfo.tsx
+++ b/packages/react-components/src/AddressInfo.tsx
@@ -222,6 +222,7 @@ function renderValidatorPrefs ({ stakingInfo, withValidatorPrefs = false }: Prop
               <FormatBalance
                 className='result'
                 value={(stakingInfo.validatorPrefs as any as ValidatorPrefsTo145).validatorPayment}
+                format={[6, "ROOT" ]}
               />
             </>
           )
@@ -248,6 +249,7 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
         formatIndex={formatIndex}
         labelPost={<IconVoid />}
         value={balancesAll ? balancesAll.freeBalance.add(balancesAll.reservedBalance) : 1}
+        format={[6, "ROOT" ]}
       />
     </React.Fragment>
   );
@@ -258,6 +260,7 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
         className='result'
         formatIndex={formatIndex}
         labelPost={<IconVoid />}
+        format={[6, "ROOT" ]}
         value={deriveBalances.availableBalance}
       />
     </React.Fragment>
@@ -279,6 +282,7 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
             />
           }
           value={deriveBalances.vestedBalance}
+          format={[6, "ROOT" ]}
         >
           <Tooltip trigger={`${address}-vested-trigger`}>
             <div>
@@ -341,6 +345,7 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
           </>
         }
         value={isAllLocked ? 'all' : deriveBalances.lockedBalance}
+        format={[6, "ROOT" ]}
       />
     </React.Fragment>
   );

--- a/packages/react-components/src/AddressInfo.tsx
+++ b/packages/react-components/src/AddressInfo.tsx
@@ -221,8 +221,8 @@ function renderValidatorPrefs ({ stakingInfo, withValidatorPrefs = false }: Prop
               <Label label={t<string>('commission')} />
               <FormatBalance
                 className='result'
+                format={[6, 'ROOT']}
                 value={(stakingInfo.validatorPrefs as any as ValidatorPrefsTo145).validatorPayment}
-                format={[6, "ROOT" ]}
               />
             </>
           )
@@ -246,10 +246,10 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
       <Label label={withLabel ? t<string>('total') : ''} />
       <FormatBalance
         className={`result ${balancesAll ? '' : '--tmp'}`}
+        format={[6, 'ROOT']}
         formatIndex={formatIndex}
         labelPost={<IconVoid />}
         value={balancesAll ? balancesAll.freeBalance.add(balancesAll.reservedBalance) : 1}
-        format={[6, "ROOT" ]}
       />
     </React.Fragment>
   );
@@ -258,9 +258,9 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
       <Label label={t<string>('transferrable')} />
       <FormatBalance
         className='result'
+        format={[6, 'ROOT']}
         formatIndex={formatIndex}
         labelPost={<IconVoid />}
-        format={[6, "ROOT" ]}
         value={deriveBalances.availableBalance}
       />
     </React.Fragment>
@@ -274,6 +274,7 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
         <Label label={t<string>('vested')} />
         <FormatBalance
           className='result'
+          format={[6, 'ROOT']}
           formatIndex={formatIndex}
           labelPost={
             <Icon
@@ -282,7 +283,6 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
             />
           }
           value={deriveBalances.vestedBalance}
-          format={[6, "ROOT" ]}
         >
           <Tooltip trigger={`${address}-vested-trigger`}>
             <div>
@@ -322,6 +322,7 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
       <Label label={t<string>('locked')} />
       <FormatBalance
         className='result'
+        format={[6, 'ROOT']}
         formatIndex={formatIndex}
         labelPost={
           <>
@@ -345,7 +346,6 @@ function createBalanceItems (formatIndex: number, lookup: Record<string, string>
           </>
         }
         value={isAllLocked ? 'all' : deriveBalances.lockedBalance}
-        format={[6, "ROOT" ]}
       />
     </React.Fragment>
   );

--- a/packages/react-components/src/StakingBonded.tsx
+++ b/packages/react-components/src/StakingBonded.tsx
@@ -23,6 +23,7 @@ function StakingBonded ({ className = '', stakingInfo }: Props): React.ReactElem
     <FormatBalance
       className={className}
       value={balance}
+      format={[6, "ROOT" ]}
     />
   );
 }

--- a/packages/react-components/src/StakingBonded.tsx
+++ b/packages/react-components/src/StakingBonded.tsx
@@ -22,8 +22,8 @@ function StakingBonded ({ className = '', stakingInfo }: Props): React.ReactElem
   return (
     <FormatBalance
       className={className}
+      format={[6, 'ROOT']}
       value={balance}
-      format={[6, "ROOT" ]}
     />
   );
 }

--- a/packages/react-components/src/StakingRedeemable.tsx
+++ b/packages/react-components/src/StakingRedeemable.tsx
@@ -45,7 +45,10 @@ function StakingRedeemable ({ className = '', isPool, stakingInfo }: Props): Rea
 
   return (
     <div className={className}>
-      <FormatBalance value={stakingInfo.redeemable} format={[6, "ROOT" ]}>
+      <FormatBalance
+        format={[6, 'ROOT']}
+        value={stakingInfo.redeemable}
+      >
         {allAccounts.includes((stakingInfo.controllerId || '').toString())
           ? (
             <TxButton

--- a/packages/react-components/src/StakingRedeemable.tsx
+++ b/packages/react-components/src/StakingRedeemable.tsx
@@ -45,7 +45,7 @@ function StakingRedeemable ({ className = '', isPool, stakingInfo }: Props): Rea
 
   return (
     <div className={className}>
-      <FormatBalance value={stakingInfo.redeemable}>
+      <FormatBalance value={stakingInfo.redeemable} format={[6, "ROOT" ]}>
         {allAccounts.includes((stakingInfo.controllerId || '').toString())
           ? (
             <TxButton

--- a/packages/react-components/src/StakingUnbonding.tsx
+++ b/packages/react-components/src/StakingUnbonding.tsx
@@ -76,7 +76,10 @@ function StakingUnbonding ({ className = '', iconPosition = 'left', stakingInfo 
           tooltip={trigger}
         />
       )}
-      <FormatBalance value={total} format={[6, "ROOT" ]} />
+      <FormatBalance
+        format={[6, 'ROOT']}
+        value={total}
+      />
       <Tooltip trigger={trigger}>
         {mapped.map(([{ value }, eras, blocks], index): React.ReactNode => (
           <div

--- a/packages/react-components/src/StakingUnbonding.tsx
+++ b/packages/react-components/src/StakingUnbonding.tsx
@@ -76,7 +76,7 @@ function StakingUnbonding ({ className = '', iconPosition = 'left', stakingInfo 
           tooltip={trigger}
         />
       )}
-      <FormatBalance value={total} />
+      <FormatBalance value={total} format={[6, "ROOT" ]} />
       <Tooltip trigger={trigger}>
         {mapped.map(([{ value }, eras, blocks], index): React.ReactNode => (
           <div

--- a/packages/react-query/src/BalanceFree.tsx
+++ b/packages/react-query/src/BalanceFree.tsx
@@ -1,9 +1,9 @@
 // Copyright 2017-2023 @polkadot/react-query authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
 import type { AccountId, AccountIndex, Address } from '@polkadot/types/interfaces';
-
+import { PalletAssetsAssetAccount } from "@polkadot/types/lookup";
+import { Option } from "@polkadot/types";
 import React from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -19,13 +19,12 @@ interface Props {
 
 function BalanceFree ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
-  const allBalances = useCall<DeriveBalancesAll>(api.derive.balances?.all, [params]);
-
+  const xrpBalance = useCall<Option<PalletAssetsAssetAccount>>(api.query.assets?.account, [2, params]);
   return (
     <FormatBalance
       className={className}
       label={label}
-      value={allBalances?.freeBalance}
+      value={xrpBalance?.unwrap()?.balance}
     >
       {children}
     </FormatBalance>

--- a/packages/react-query/src/BalanceFree.tsx
+++ b/packages/react-query/src/BalanceFree.tsx
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AccountId, AccountIndex, Address } from '@polkadot/types/interfaces';
-import { PalletAssetsAssetAccount } from "@polkadot/types/lookup";
-import { Option } from "@polkadot/types";
+
 import React from 'react';
 
 import { useApi, useCall } from '@polkadot/react-hooks';
+import { Option } from '@polkadot/types';
+import { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
 
 import FormatBalance from './FormatBalance';
 
@@ -20,6 +21,7 @@ interface Props {
 function BalanceFree ({ children, className = '', label, params }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const xrpBalance = useCall<Option<PalletAssetsAssetAccount>>(api.query.assets?.account, [2, params]);
+
   return (
     <FormatBalance
       className={className}

--- a/packages/react-query/src/FormatBalance.tsx
+++ b/packages/react-query/src/FormatBalance.tsx
@@ -35,8 +35,7 @@ type LabelPost = string | React.ReactNode
 
 function getFormat (registry: Registry, formatIndex = 0): [number, string] {
   const decimals = registry.chainDecimals;
-  const tokens = registry.chainTokens;
-
+  const tokens = ['XRP'];
   return [
     formatIndex < decimals.length
       ? decimals[formatIndex]

--- a/packages/react-query/src/FormatBalance.tsx
+++ b/packages/react-query/src/FormatBalance.tsx
@@ -36,6 +36,7 @@ type LabelPost = string | React.ReactNode
 function getFormat (registry: Registry, formatIndex = 0): [number, string] {
   const decimals = registry.chainDecimals;
   const tokens = ['XRP'];
+
   return [
     formatIndex < decimals.length
       ? decimals[formatIndex]


### PR DESCRIPTION
## Summary

Closes https://futureverse.atlassian.net/browse/TRN-110

- Event details in block show gas is paid in ROOT, should be in XRP
- Also, on extrinsic page, balance is now displayed for XRP.

There is alternate way to make this happen, if we change the following line in seed repo
https://github.com/futureversecom/trn-seed/blob/8e92a513bb6de4e23a5b06ce452df18c29e2ae7a/chain-spec/porcini.json#L17

If we change "tokenSymbol": "ROOT" to "tokenSymbol": "XRP", then won't need to change it in portal

## Checklist

- [x] Add description
- [x] Tag related issue(s)
