### PR TITLE
[Fix] Change epoch label

### DIFF
--- a/packages/page-explorer/src/SummarySession.tsx
+++ b/packages/page-explorer/src/SummarySession.tsx
@@ -26,9 +26,10 @@ function SummarySession ({ className, withEra = true, withSession = true }: Prop
   const forcing = useCall<Forcing>(api.query.staking?.forceEra);
 
   const eraLabel = t<string>('era');
-  const sessionLabel = api.query.babe
-    ? t<string>('epoch')
-    : t<string>('session');
+  // const sessionLabel = api.query.babe
+  //   ? t<string>('epoch')
+  //   : t<string>('session');
+  const sessionLabel = t<string>('session');
   const activeEraStart = sessionInfo?.activeEraStart.unwrapOr(null);
 
   return (


### PR DESCRIPTION
## Summary

On TRN, `epoch` and `session` has the same value, renamed the label to `session` to avoid confusion from validators / developers

Source: https://futureverse.slack.com/archives/C04DG8AQSGY/p1709685512621849?thread_ts=1709599856.413139&cid=C04DG8AQSGY

## Checklist

- [x] Add description
- [x] Tag related issue(s)
