### PR TITLE
Fix `signAndSend` call in JS Console of the Portal doesnt show the output

### DIFF
--- a/packages/page-explorer/src/SummarySession.tsx
+++ b/packages/page-explorer/src/SummarySession.tsx
@@ -26,9 +26,10 @@ function SummarySession ({ className, withEra = true, withSession = true }: Prop
   const forcing = useCall<Forcing>(api.query.staking?.forceEra);
 
   const eraLabel = t<string>('era');
-  const sessionLabel = api.query.babe
-    ? t<string>('epoch')
-    : t<string>('session');
+  // const sessionLabel = api.query.babe
+  //   ? t<string>('epoch')
+  //   : t<string>('session');
+  const sessionLabel = t<string>('session');
   const activeEraStart = sessionInfo?.activeEraStart.unwrapOr(null);
 
   return (

--- a/packages/trnsp-custom/src/components/TxExternalSigned.tsx
+++ b/packages/trnsp-custom/src/components/TxExternalSigned.tsx
@@ -90,13 +90,15 @@ function TxSigned ({ className, currentItem, requestAddress }: Props): React.Rea
         try {
           const signedExtrinsic = await signWithEthereumWallet(api, senderInfo.signAddress, currentItem.extrinsic, { tip });
           const signature = u8aToHex(signedExtrinsic.signature);
+
           queueSetTxStatus(currentItem.id, 'sending');
 
           if (signedExtrinsic.send) {
             currentItem.txStartCb && currentItem.txStartCb();
             const unsubscribe: () => void = await signedExtrinsic.send(handleTxResults('signAndSend', queueSetTxStatus, currentItem, () => unsubscribe()));
           } else {
-            const { id,  signerCb = NOOP } = currentItem;
+            const { id, signerCb = NOOP } = currentItem;
+
             signerCb(id, { id, signature });
           }
         } catch (error) {

--- a/packages/trnsp-custom/src/components/TxExternalSigned.tsx
+++ b/packages/trnsp-custom/src/components/TxExternalSigned.tsx
@@ -6,16 +6,14 @@ import type { BN } from '@polkadot/util';
 
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { SubmittableResult } from '@polkadot/api';
 import { Button, ErrorBoundary, Modal, Output, styled } from '@polkadot/react-components';
-import { QueueTxStatus } from '@polkadot/react-components/Status/types';
 import { useApi, useQueue, useToggle } from '@polkadot/react-hooks';
 import Address from '@polkadot/react-signer/Address';
 import Tip from '@polkadot/react-signer/Tip';
 import Transaction from '@polkadot/react-signer/Transaction';
 import { useTranslation } from '@polkadot/react-signer/translate';
 import { handleTxResults } from '@polkadot/react-signer/util';
-import { nextTick } from '@polkadot/util';
+import { nextTick, u8aToHex } from '@polkadot/util';
 
 import { signWithEthereumWallet } from '../utils/signWithEthereumWallet';
 
@@ -31,6 +29,7 @@ interface InnerTx {
 }
 
 const EMPTY_INNER: InnerTx = { innerHash: null, innerTx: null };
+const NOOP = () => undefined;
 
 function TxSigned ({ className, currentItem, requestAddress }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
@@ -90,25 +89,18 @@ function TxSigned ({ className, currentItem, requestAddress }: Props): React.Rea
 
         try {
           const signedExtrinsic = await signWithEthereumWallet(api, senderInfo.signAddress, currentItem.extrinsic, { tip });
-
+          const signature = u8aToHex(signedExtrinsic.signature);
           queueSetTxStatus(currentItem.id, 'sending');
 
           if (signedExtrinsic.send) {
             currentItem.txStartCb && currentItem.txStartCb();
             const unsubscribe: () => void = await signedExtrinsic.send(handleTxResults('signAndSend', queueSetTxStatus, currentItem, () => unsubscribe()));
           } else {
-            const unsubscribe = await api.rpc.author.submitAndWatchExtrinsic(currentItem.extrinsic, (res): void => {
-              const status = res.type.toLowerCase() as QueueTxStatus;
-
-              queueSetTxStatus(currentItem.id, status, res);
-
-              if (currentItem?.txUpdateCb) {
-                currentItem?.txUpdateCb(res as unknown as SubmittableResult);
-                unsubscribe();
-              }
-            });
+            const { id,  signerCb = NOOP } = currentItem;
+            signerCb(id, { id, signature });
           }
         } catch (error) {
+          queueSetTxStatus(currentItem.id, 'error', null, error as Error);
           const { code, message } = error as {code: number, message: string};
 
           if (code) {


### PR DESCRIPTION
When extrinsic is signed via js portal and metamask, the call back does not return and outputs the data.. This PR addresses the issue